### PR TITLE
Feature/i10 show score history

### DIFF
--- a/public/lab3/index.html
+++ b/public/lab3/index.html
@@ -94,8 +94,8 @@
         <h2 id="totalScore" class="text-info"></h2>
         <h2 id="congrats" class="text-info"></h2>
         <h3 id="highScore" class="text-primary"></h3>
-        <h4>Number of attempts: <span id="numberOfAttempts"></span></h4>
-        <h4>Score tracking: <span id="scoreTracker"></span></h4>
+        <h4 id="numberOfAttempts"></h4>
+        <h4 id="scoreTracker"></h4>
         <br>
         <script src="js/guessGame.js"></script>
     </body>

--- a/public/lab3/js/guessGame.js
+++ b/public/lab3/js/guessGame.js
@@ -121,8 +121,8 @@ function getScoreInfo() {
         });
         let highscore = Math.max(...scores);
 
-        $("#numberOfAttempts").html(attempts);
-        $("#scoreTracker").html(scoreHistory);
+        $("#numberOfAttempts").html(`Number of attempts: ${attempts}`);
+        $("#scoreTracker").html(`Score history: ${scoreHistory}`);
 
         if (highscore) {
             $("#highScore").html(`Current highscore: ${highscore}`);


### PR DESCRIPTION
Added tracking for number of attempts and full score history at the bottom of the page. This is only shown if there is data i local storage.

Fixes #10 